### PR TITLE
Set SNI hostname TLS handshake failures

### DIFF
--- a/libwsc/WebSocketClient.cpp
+++ b/libwsc/WebSocketClient.cpp
@@ -119,7 +119,6 @@ void WebSocketClient::connect() {
 
         ssl = SSL_new(ctx);
 
-        SSL_set_tlsext_host_name(ssl, host.c_str());
 
         if (!ssl) {
             SSL_CTX_free(ctx);
@@ -127,6 +126,8 @@ void WebSocketClient::connect() {
             sendError(ErrorCode::TLS_INIT_FAILED, "SSL context creation failed");
             return;
         }
+
+        SSL_set_tlsext_host_name(ssl, host.c_str());
 
         if (!tlsOptions.disableHostnameValidation) {
             X509_VERIFY_PARAM* param = SSL_get0_param(ssl);

--- a/libwsc/WebSocketClient.cpp
+++ b/libwsc/WebSocketClient.cpp
@@ -119,6 +119,8 @@ void WebSocketClient::connect() {
 
         ssl = SSL_new(ctx);
 
+        SSL_set_tlsext_host_name(ssl, host.c_str());
+
         if (!ssl) {
             SSL_CTX_free(ctx);
             log_error("SSL_new() failed");


### PR DESCRIPTION
Hi there,

While trying to connect to OpenAI's Realtime API (`wss://api.openai.com/v1/realtime`) using `libwsc`, I was hitting a TLS handshake failure the connection was dropped before even reaching the WebSocket upgrade step. I also ran into the same issue with other public WebSocket secure endpoints.

I'm not very experienced with TLS internals, but setting the SNI hostname explicitly using `SSL_set_tlsext_host_name(ssl, host.c_str());` fixed it for me. Without it, the server would immediately close the connection. 

I’m not sure this is the right fix or the best place to add it, but it’s what got things working on my side and hopefully it helps start a conversation around it.

Thanks for maintaining this library and `mod_audio_stream`!